### PR TITLE
Ansible linting to version 3.0

### DIFF
--- a/roles/ovirt-common/tasks/main.yml
+++ b/roles/ovirt-common/tasks/main.yml
@@ -4,13 +4,15 @@
   yum:
     name: '*'
     state: "latest"
+  tags:
+    -skip_ansible_lint
 
 # install libselinux-python on machine - selinux policy
 # allow to install engine TODO
 - name: install libselinux-python for ansible
   yum:
     name: libselinux-python
-    state: "latest"
+    state: "present"
 
 # backup repos
 - name: creating directory repo-backup in yum.repos.d
@@ -20,6 +22,8 @@
 
 - name: create repository backup
   shell: 'cp /etc/yum.repos.d/*.repo /tmp/repo-backup'
+  tags:
+    -skip_ansible_lint
 
 # get repository templates
 - name: copy {{ovirt_engine_type}} repository file

--- a/roles/ovirt-engine-remote-db/tasks/main.yml
+++ b/roles/ovirt-engine-remote-db/tasks/main.yml
@@ -18,6 +18,8 @@
 - name: run PostgreSQL initdb
   shell: '/usr/bin/initdb -D /var/lib/pgsql/data'
   when: postgresql_status|failed
+  tags:
+    -skip_ansible_lint
 
 - name: start PostgreSQL service
   service:

--- a/roles/ovirt-engine-setup/tasks/main.yml
+++ b/roles/ovirt-engine-setup/tasks/main.yml
@@ -23,6 +23,8 @@
 - name: run engine-setup with answerfile
   shell: 'engine-setup --config-append=/tmp/answer_file.txt'
   when: ovirt_engine_status|failed
+  tags:
+    -skip_ansible_lint
 
 - name: check state of database
   service:


### PR DESCRIPTION
As we decided to leave udpate of pacakges to tox, we need to upgrade tests to ansible-lint-3.0
For local setup it is enough to remove .tox folder and leave the rest to tox.

Go by the new ansible-lint version rules, or ignore them with tags skip_ansible_lint :)